### PR TITLE
feat: add cachix

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,4 +16,10 @@ jobs:
           extra_nix_config: |
             access-tokens = github=${{ secrets.GITHUB_TOKEN }}
 
+      - name: Setup nix cache
+        uses: cachix/cachix-action@v10
+        with:
+          name: justinrubek-ci-comparison
+          authToken: "${{ secrets.CACHIX_AUTH_TOKEN }}"
+
       - run: nix flake check

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,19 @@
+name: CI
+on: push
+
+jobs:
+  test:
+    name: tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Install nix
+        uses: cachix/install-nix-action@v15
+        with:
+          extra_nix_config: |
+            access-tokens = github=${{ secrets.GITHUB_TOKEN }}
+
+      - run: nix flake check

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,3 +1,3 @@
 fn main() {
-    println!("Hello, world!");
+    println!("Hello, cachix!");
 }


### PR DESCRIPTION
Breaking down this PR: 

cceaf93 - This is the first commit with cachix, so the cache is not populated. This results in an extra 38 seconds added to upload artifacts at the end of the run

4f93cc3 - This only changes the `cli` crate, so a lot of the building done previously can be reused

| commit | total ci time |
| --- | --- |
| 1b03c2f | 93s |
| cceaf93 | 133s |
| 4f93cc3 | 61s |

There is a slightly higher time usage for initial builds, but subsequent ones can be faster as a result of the cache.